### PR TITLE
Updated README to reflect actual API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,17 @@ A rust implementation of FSRS.
 Quickstart:
 ```rust
 use chrono::Utc;
-use fsrs::FSRS;
-use fsrs::models::{Card, Rating::Easy};
-
+use fsrs::{FSRS, Card, Rating::Easy};
 
 fn main() {
-    let mut fsrs = FSRS::default();
+    let fsrs = FSRS::default();
+    let card = Card::new();
+    
+    let scheduled_cards = fsrs.schedule(card, Utc::now());
 
-    let mut card = Card::new();
-    fsrs.schedule(&mut card, Utc::now());
+    let updated_card = scheduled_cards.select_card(Easy);
 
-    card = fsrs.select_card(Easy);
-
-    println!("{}", card.scheduled_days);
+    println!("{:?}", updated_card.log);
 }
 ```
 


### PR DESCRIPTION
The README now reflects the proper API. i.e. the FSRS struct instance does not need to be mutable, and neither does the card since a new card is returned once selected. It certainly can be if the user wants to overwrite the card, but it is no longer a requirement of the API for things to be mutable