### PR TITLE
Removed the need for lifetimes with ScheduledCards

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -177,7 +177,7 @@ impl FSRS {
                     card.difficulty - (self.params.w[6] * (rating_int as f32 - 3.0));
                 let mean_reversion = self.mean_reversion(self.params.w[4], next_difficulty);
                 card.difficulty = mean_reversion.max(1.0).min(10.0);
-                output_cards.cards.insert(rating, card);
+                output_cards.cards.insert(*rating, card);
             }
         }
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -31,7 +31,7 @@ pub struct ScheduledCards {
     pub now: DateTime<Utc>,
 }
 
-impl ScheduledCards{
+impl ScheduledCards {
     pub fn new(card: &Card, now: DateTime<Utc>) -> Self {
         let mut cards = HashMap::new();
         for rating in Rating::iter() {

--- a/src/models.rs
+++ b/src/models.rs
@@ -26,16 +26,16 @@ impl Rating {
 }
 
 #[derive(Debug, Clone)]
-pub struct ScheduledCards<'a> {
-    pub cards: HashMap<&'a Rating, Card>,
+pub struct ScheduledCards {
+    pub cards: HashMap<Rating, Card>,
     pub now: DateTime<Utc>,
 }
 
-impl ScheduledCards<'_> {
+impl ScheduledCards{
     pub fn new(card: &Card, now: DateTime<Utc>) -> Self {
         let mut cards = HashMap::new();
         for rating in Rating::iter() {
-            cards.insert(rating, card.clone());
+            cards.insert(*rating, card.clone());
             if let Some(card) = cards.get_mut(rating) {
                 card.update_state(*rating);
             }


### PR DESCRIPTION
I've finally gotten around to setting up the actual SR system in my app, and I realized there is literally no need for lifetimes with the ScheduledCards struct which was just adding more complexity. 
- I changed  HashMap<&Rating, Card> -> HashMap<Rating, Card>

Removing the reference here removes the need for lifetimes, and when using it inside the lib, we just need to derefence the ratings.