### PR TITLE
Hard and Easy scheduling fix

### DIFF
--- a/src/algo.rs
+++ b/src/algo.rs
@@ -2,8 +2,8 @@ use crate::models::Rating;
 use crate::models::Rating::{Again, Easy, Good, Hard};
 use crate::models::State::{Learning, New, Relearning, Review};
 use crate::models::*;
-use std::cmp;
 use chrono::{DateTime, Duration, Utc};
+use std::cmp;
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct FSRS {

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -187,6 +187,6 @@ impl FSRS {
     }
 
     fn mean_reversion(&self, initial: f32, current: f32) -> f32 {
-        return self.params.w[7] * initial + (1.0 - self.params.w[7]) * current;
+        self.params.w[7] * initial + (1.0 - self.params.w[7]) * current
     }
 }


### PR DESCRIPTION
Some more oversights on my part. I suppose we might want to updated the tests to test against a more diverse set of ratings and instances. 

I've been reviewing cards daily with these fixes and I think these are the last of the bugs. Seems to be functioning as expected now. I also changed the code that ensures hard < good < easy to use std::cmp