### PR TITLE
Add Serde support (hidden behind a feature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,11 @@ edition = "2021"
 
 [dependencies]
 chrono = {version = "0.4.23", features = ["serde"]}
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0.93"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0.93", optional = true }
+
+[features]
+serde = [
+  "dep:serde",
+  "dep:serde_json"
+]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,10 +1,10 @@
 use chrono::{DateTime, Utc};
-#[cfg(serde)]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, PartialEq, Debug, Default, Eq)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum State {
     #[default]
     New = 0,
@@ -14,7 +14,7 @@ pub enum State {
 }
 
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Rating {
     Again = 1,
     Hard = 2,
@@ -55,7 +55,7 @@ impl ScheduledCards {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ReviewLog {
     pub rating: Rating,
     pub elapsed_days: i64,
@@ -85,7 +85,7 @@ impl Default for Parameters {
 }
 
 #[derive(Clone, Debug, Default)]
-#[cfg_attr(serde, derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Card {
     pub due: DateTime<Utc>,
     pub stability: f32,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,8 +1,10 @@
 use chrono::{DateTime, Utc};
+#[cfg(serde)]
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, Default, Eq)]
+#[derive(Clone, Copy, PartialEq, Debug, Default, Eq)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub enum State {
     #[default]
     New = 0,
@@ -11,7 +13,8 @@ pub enum State {
     Relearning = 3,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub enum Rating {
     Again = 1,
     Hard = 2,
@@ -51,7 +54,8 @@ impl ScheduledCards {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub struct ReviewLog {
     pub rating: Rating,
     pub elapsed_days: i64,
@@ -80,7 +84,8 @@ impl Default for Parameters {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[derive(Clone, Debug, Default)]
+#[cfg_attr(serde, derive(Serialize, Deserialize))]
 pub struct Card {
     pub due: DateTime<Utc>,
     pub stability: f32,

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Copy, PartialEq, Debug, Default, Eq)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug, Default, Eq)]
 pub enum State {
     #[default]
     New = 0,
@@ -10,7 +11,7 @@ pub enum State {
     Relearning = 3,
 }
 
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Copy, Clone, Debug)]
 pub enum Rating {
     Again = 1,
     Hard = 2,
@@ -50,7 +51,7 @@ impl ScheduledCards {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ReviewLog {
     pub rating: Rating,
     pub elapsed_days: i64,
@@ -79,7 +80,7 @@ impl Default for Parameters {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct Card {
     pub due: DateTime<Utc>,
     pub stability: f32,


### PR DESCRIPTION
- Implemented Serialize and Deserialize traits for structs Card, State, Rating and ReviewLog.
- The Serde support is hidden behind a feature named "serde."

## Why?
For interoperability. See [Rust API Guidelines Checklist](https://rust-lang.github.io/api-guidelines/checklist.html).

Because users of the rs-fsrs crate cannot implement or derive Serialize or Deserialize traits by themselves. It is a best practice to add a serde feature for enabling users to optionally serialize data structs.