### PR TITLE
Make ReviewLog public, so previously reviewed cards can be added

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,5 @@ mod algo;
 pub use algo::FSRS;
 
 mod models;
-pub use models::{Card, Rating, State};
+pub use models::{Card, Rating, ReviewLog, State};
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod algo;
 pub use algo::FSRS;
 
+mod models;
 pub use models::{Card, Rating, ReviewLog, State};
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,5 @@ mod algo;
 pub use algo::FSRS;
 
 mod models;
-pub use models::{Card, Rating};
+pub use models::{Card, Rating, State};
 mod tests;


### PR DESCRIPTION
- Made State public in another PR, but forgot to also include ReviewLog. This is the last struct referenced by Card that was not previously public.